### PR TITLE
Updated repository cpan metadata & removed bugtracker

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -182,10 +182,9 @@ ExtUtils::MakeMaker::WriteMakefile(
      (MIN_PERL_VERSION => 5.006,
       META_MERGE => {
           resources=> {
-              repository => 'https://soaplite.svn.sourceforge.net/svnroot/soaplite/branches/0.71',
+              repository => 'https://github.com/redhotpenguin/soaplite',
           },
           keywords => ['SOAP','SOAP client','SOAP server'],
-          bugtracker => 'https://sourceforge.net/tracker/?group_id=66000&atid=513017',
           
       },
      ) : ()),


### PR DESCRIPTION
Removed bugtracker since it was in the wrong place (should have been with repository in resources), it appears that there is a move away from sourceforge in general for the project and RT is doing the job handling tickets anyways.  There are 9 open bug still in the sourceforge bug tracker so there should likely be a process of of seeing if they are still issues and having them moved to RT.  For instance you could ask the submitters to do the checking and resubmitting.
