### PR TITLE
Skip XML::Parser::Lite tests if it is missing

### DIFF
--- a/t/36-leaks.t
+++ b/t/36-leaks.t
@@ -62,17 +62,23 @@ plan tests => 16;
     ok(exists $calls{DESTROY}{$_});
   }
 
-  %calls = ();
-  {
-    local $SOAP::Constants::DO_NOT_USE_XML_PARSER = 1;
-    my $soap = SOAP::Lite
-      -> uri("Echo")
-      -> proxy($proxy)
-      -> echo;
-  }
-  foreach (keys %{$calls{new}}) {
-    print "XML::Parser::Lite: $_\n";
-    ok(exists $calls{DESTROY}{$_});
+
+  SKIP: {
+      eval "require XML::Parser::Lite; 1;";
+      skip "XML::Parser::Lite is required for this test", 8 if $@;
+
+      %calls = ();
+      {
+          local $SOAP::Constants::DO_NOT_USE_XML_PARSER = 1;
+          my $soap = SOAP::Lite
+          -> uri("Echo")
+          -> proxy($proxy)
+          -> echo;
+      }
+      foreach (keys %{$calls{new}}) {
+          print "XML::Parser::Lite: $_\n";
+          ok(exists $calls{DESTROY}{$_});
+      }
   }
 
   # SOAP::Lite->import(trace => '-objects');


### PR DESCRIPTION
We simply try to load it in an eval, and if that fails, we skip the second half
of the tests.

This should make it possible to install SOAP::Lite on a fresh system again,
since right now there is a circular dep between SOAP::Lite and
XML::Parser::Lite, resulting in uninstallable modules unless you force one or
the other.

This fixes RT#87605
