### PR TITLE
89948, Remove warning when Content-Id is not present

### DIFF
--- a/lib/SOAP/Lite.pm
+++ b/lib/SOAP/Lite.pm
@@ -2122,8 +2122,7 @@ sub decode_parts {
             : ['mimepart', {}, $data];
         # This below looks like unnecessary bloat!!!
         # I should probably dereference the mimepart, provide a callback to get the string data
-        $id =~ s/^<([^>]*)>$/$1/; # string any leading and trailing brackets
-        $self->ids->{$id} = $part if $id;
+        $self->ids->{$1} = $part if ($id && $id =~ m/^<([^>]+)>$/); # strip any leading and trailing brackets
         $self->ids->{$location} = $part if $location;
     }
     return $body;


### PR DESCRIPTION
According to http://www.w3.org/TR/SOAP-attachments

> Referenced MIME parts must contain either a Content-ID MIME header
> structured in accordance with RFC 2045, or a Content-Location
> MIME header structured in accordance with RFC 2557

Content-Id is not mandatory and can be undefined.

Fix warning produced after applying regexp to an undefined value of
Content-Id in such cases.
