### PR TITLE
fix RT#15703

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -83,7 +83,9 @@ ExtUtils::MakeMaker::WriteMakefile(
                     repository => 'https://github.com/redhotpenguin/soaplite',
                 },
                 keywords => [ 'SOAP', 'SOAP client', 'SOAP server' ],
-
+                no_index => {
+                    directory => [ qw( examples t ) ],
+                },
             },
           )
         : ()


### PR DESCRIPTION
Hi,

I've added a `no_index` field for _examples/_ and also for _t/_ directories, as discussed in [this issue](https://rt.cpan.org/Public/Bug/Display.html?id=15703).

Cheers,
Sergey
