### PR TITLE
avoid string eval in as_base64

### DIFF
--- a/lib/SOAP/Constants.pm
+++ b/lib/SOAP/Constants.pm
@@ -46,6 +46,7 @@ use vars qw($NEXT_ACTOR $NS_ENV $NS_ENC $NS_APS
     @SUPPORTED_ENCODING_STYLES $OBJS_BY_REF_KEEPALIVE
     $DEFAULT_CACHE_TTL
     %XML_SCHEMA_OF
+    $HAS_ENCODE
 );
 
 $FAULT_CLIENT           = 'Client';
@@ -124,6 +125,8 @@ $OBJS_BY_REF_KEEPALIVE = 600; # seconds
 # TODO - use default packager constant somewhere
 $DEFAULT_PACKAGER = "SOAP::Packager::MIME";
 $DEFAULT_CACHE_TTL = 0;
+
+$HAS_ENCODE = eval "require Encode; 1";
 
 1;
 

--- a/lib/SOAP/Lite.pm
+++ b/lib/SOAP/Lite.pm
@@ -114,7 +114,7 @@ sub as_base64 {
     # Fixes #30271 for 5.8 and above.
     # Won't fix for 5.6 and below - perl can't handle unicode before
     # 5.8, and applying pack() to everything is just a slowdown.
-    if (eval "require Encode; 1") {
+    if ($SOAP::Constants::HAS_ENCODE) {
         if (Encode::is_utf8($value)) {
             if (Encode->can('_utf8_off')) { # the quick way, but it may change in future Perl versions.
                 Encode::_utf8_off($value);


### PR DESCRIPTION
There is a string eval repeated in as_base64, which slows down the serialization unnecessarily. Is is only required to do the check once.
