### PR TITLE
added on_debug

### DIFF
--- a/lib/SOAP/Lite.pm
+++ b/lib/SOAP/Lite.pm
@@ -17,7 +17,7 @@ package SOAP::Lite;
 use strict;
 use warnings;
 
-our $VERSION = '1.11';
+our $VERSION = '1.12';
 
 package SOAP::XMLSchemaApacheSOAP::Deserializer;
 

--- a/lib/SOAP/Transport/HTTP.pm
+++ b/lib/SOAP/Transport/HTTP.pm
@@ -10,7 +10,7 @@ package SOAP::Transport::HTTP;
 
 use strict;
 
-our $VERSION = 1.11;
+our $VERSION = 1.12;
 
 use SOAP::Lite;
 use SOAP::Packager;


### PR DESCRIPTION
Allows debug callback by connection instead of globally.  This allows, for instance, 2 different SOAP connections to have different logfiles for talking to different systems.
