### PR TITLE
Remove dependency on Crypt::SSLeay

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -25,7 +25,6 @@ my %WriteMakefileArgs = (
   "PREREQ_PM" => {
     "Class::Inspector" => 0,
     "Compress::Zlib" => 0,
-    "Crypt::SSLeay" => 0,
     "IO::SessionData" => "1.03",
     "IO::Socket::SSL" => 0,
     "LWP::UserAgent" => 0,


### PR DESCRIPTION
As described [in SSLeay.pm](http://search.cpan.org/dist/Crypt-SSLeay/SSLeay.pm#DO_YOU_NEED_Crypt::SSLeay?) once you've established a dependency on IO::Socket::SSL you probably don't need Crypt::SSLeay. This is good news, because I'm having real trouble compiling Crypt::SSLeay on windows 7.

I've installed SOAP::Lite with this line deleted three times, on windows 7 (perl 5.16), windows server 2012 (perl 5.18), and OSX Yosemite (perl 5.12) with no adverse effects, so I'd like it removed so I can go back to just running cpanm!