### PR TITLE
Preventing "billion laughs" exponential entity expansion attack

### DIFF
--- a/lib/SOAP/Lite.pm
+++ b/lib/SOAP/Lite.pm
@@ -1741,7 +1741,7 @@ sub xmlparser {
             ? undef
             : do {
                 require XML::Parser;
-                XML::Parser->new() }
+                XML::Parser->new( NoExpand => 1, Handlers => { Default => sub {} } ) }
             }
             || eval { require XML::Parser::Lite; XML::Parser::Lite->new }
             || die "XML::Parser is not @{[$SOAP::Constants::DO_NOT_USE_XML_PARSER ? 'used' : 'available']} and ", $@;
@@ -4165,7 +4165,7 @@ If using $session->call ($method, $callData, $callHeader), SOAP::Lite serializes
     </soap:Header>
     <soap:Body>
       <myMethod xmlns="http://www.someuri.com">
-        <foo />  
+        <foo />
       </myMethod>
     </soap:Body>
   </soap:Envelope>


### PR DESCRIPTION
Hey, I noticed, that SOAP::Lite is vulnerable to xml bombs [1]. I tried to solve the problem by initializing the XML::Parser object by avoiding to expand references to entities defined in the internal subset.

I did not make those changes optional or configurable since "The XML infoset of a SOAP message MUST NOT contain a document type declaration information item." [2].

My changes do not affect the creation of XML::Parser::Lite objects, because in my local tests XML::Parser::Lite did not seem to blow up memory or cpu usage.

~Thilo

[1] https://en.wikipedia.org/wiki/Billion_laughs
[2] http://www.w3.org/TR/2007/REC-soap12-part1-20070427/#soapenv