### PR TITLE
fix: do not set content_length for compressed request

### DIFF
--- a/lib/SOAP/Transport/HTTP.pm
+++ b/lib/SOAP/Transport/HTTP.pm
@@ -268,7 +268,7 @@ sub send_receive {
                   if ( $tmpType !~ /$addition/ );
             }
 
-            $http_request->content_length($bytelength);
+            $http_request->content_length($bytelength) unless $compressed;
             SOAP::Trace::transport($http_request);
             &{$self->{debug_logger}}($http_request->as_string);
 


### PR DESCRIPTION
just let it LWP to calculate it
this should fix recalculation of length in LWP::Protocol::http (newest versions)
 with message like 'Content-Length header value was wrong, fixed'