### PR TITLE
Set minimum version of dep XML::Parser::Lite

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -79,7 +79,7 @@ SOAP::Transport::JABBER = 0.712     ; for examples
 IO::File = 0
 Test::More = 0
 Test::Warn = 0
-XML::Parser::Lite = 0
+XML::Parser::Lite = 0.715
 
 [Prereqs / TestRecommends]
 IO::Scalar = 2.105


### PR DESCRIPTION
This is a simple PR in response to [RT 104101](https://rt.cpan.org/Public/Bug/Display.html?id=104101) which points out that newer versions of XML::Parser::Lite are required to avoid the [earlier-reported bug](https://rt.cpan.org/Public/Bug/Display.html?id=53375).

I've been assigned this dist as part of the [CPAN PR Challenge](http://cpan-prc.org/) and would welcome any pointers to areas you think might benefit from attention - otherwise I'll look further at the open RT tickets and outstanding kwalitee reports.