### PR TITLE
Fix for RT 107924

### DIFF
--- a/lib/SOAP/Transport/HTTP.pm
+++ b/lib/SOAP/Transport/HTTP.pm
@@ -124,6 +124,11 @@ sub new {
 
     while (@methods) {
         my ( $method, $params ) = splice( @methods, 0, 2 );
+        # ssl_opts takes a hash, not a ref - see RT 107924
+		if (ref $params eq 'HASH' && $method eq 'ssl_opts') {
+            $self->$method( %$params );
+            next;
+        }
         $self->$method( ref $params eq 'ARRAY' ? @$params : $params );
     }
 

--- a/lib/SOAP/Transport/HTTP.pm
+++ b/lib/SOAP/Transport/HTTP.pm
@@ -125,7 +125,7 @@ sub new {
     while (@methods) {
         my ( $method, $params ) = splice( @methods, 0, 2 );
         # ssl_opts takes a hash, not a ref - see RT 107924
-		if (ref $params eq 'HASH' && $method eq 'ssl_opts') {
+        if (ref $params eq 'HASH' && $method eq 'ssl_opts') {
             $self->$method( %$params );
             next;
         }

--- a/t/Issues/rt107924.t
+++ b/t/Issues/rt107924.t
@@ -7,13 +7,10 @@ my ($opts, $soap);
 my $proxy = 'http://services.soaplite.com/echo.cgi';
 my $cafile = '/foo/bar';
 
-$opts = [ SSL_ca_file => $cafile ];
+$opts = [ verify_hostname => 0, SSL_ca_file => $cafile ];
 $soap = SOAP::Lite->proxy ($proxy, ssl_opts => $opts);
 is ($soap->transport->ssl_opts ('SSL_ca_file'), $cafile, "ssl_opts as arrayref is honoured");
 
-$opts = { SSL_ca_file => $cafile };
+$opts = { verify_hostname => 0, SSL_ca_file => $cafile };
 $soap = SOAP::Lite->proxy ($proxy, ssl_opts => $opts);
-TODO: {
-	local $TODO = 'Arg to ssl_opts should be able to be hashref';
-	is ($soap->transport->ssl_opts ('SSL_ca_file'), $cafile, "ssl_opts as hashref is honoured");
-}
+is ($soap->transport->ssl_opts ('SSL_ca_file'), $cafile, "ssl_opts as hashref is honoured");

--- a/t/Issues/rt107924.t
+++ b/t/Issues/rt107924.t
@@ -1,0 +1,19 @@
+use strict;
+use warnings;
+use Test::More tests => 2;
+use SOAP::Lite;
+
+my ($opts, $soap);
+my $proxy = 'http://services.soaplite.com/echo.cgi';
+my $cafile = '/foo/bar';
+
+$opts = [ SSL_ca_file => $cafile ];
+$soap = SOAP::Lite->proxy ($proxy, ssl_opts => $opts);
+is ($soap->transport->ssl_opts ('SSL_ca_file'), $cafile, "ssl_opts as arrayref is honoured");
+
+$opts = { SSL_ca_file => $cafile };
+$soap = SOAP::Lite->proxy ($proxy, ssl_opts => $opts);
+TODO: {
+	local $TODO = 'Arg to ssl_opts should be able to be hashref';
+	is ($soap->transport->ssl_opts ('SSL_ca_file'), $cafile, "ssl_opts as hashref is honoured");
+}


### PR DESCRIPTION
Here is an implementation (with tests) of a fix for [RT 107924](https://rt.cpan.org/Public/Bug/Display.html?id=107924). It supposes that Steffen's second suggestion ("Handle ssl_opts in a special way in SOAP::Lite") is the way to go, which may not necessarily be how you want to play it but seemed like a good first cut to me.