### PR TITLE
Consistently use '#!/usr/bin/env perl' throughout.

### DIFF
--- a/Changes
+++ b/Changes
@@ -15,6 +15,9 @@ http://rt.cpan.org/Public/Dist/Display.html?Name=SOAP-Lite
 THIS RELEASE
 -----------------------------------------------------------------------
 
+1.21 November 6, 2016
+    ! #118654 consistently use '#!/usr/bin/env perl' throughout (@mototimo) [github/moto-timo]
+
 1.20 June 9, 2016
     ! Minor kwalitee updates (@oeuftete)
     ! #106688 encode utf8 content in test which fails under RHES 6.6

--- a/bin/SOAPsh.pl
+++ b/bin/SOAPsh.pl
@@ -1,4 +1,4 @@
-#!/bin/env perl
+#!/usr/bin/env perl
 #!d:\perl\bin\perl.exe
 
 # -- SOAP::Lite -- soaplite.com -- Copyright (C) 2001 Paul Kulchenko --

--- a/t/01-core.t
+++ b/t/01-core.t
@@ -1,4 +1,4 @@
-#!/bin/env perl
+#!/usr/bin/env perl
 
 BEGIN {
   unless(grep /blib/, @INC) {

--- a/t/02-payload.t
+++ b/t/02-payload.t
@@ -1,4 +1,4 @@
-#!/bin/env perl
+#!/usr/bin/env perl
 
 BEGIN {
   unless(grep /blib/, @INC) {

--- a/t/03-server.t
+++ b/t/03-server.t
@@ -1,4 +1,4 @@
-#!/bin/env perl
+#!/usr/bin/env perl
 
 BEGIN {
     unless(grep /blib/, @INC) {

--- a/t/04-attach.t
+++ b/t/04-attach.t
@@ -1,4 +1,4 @@
-#!/bin/env perl
+#!/usr/bin/env perl
 
 BEGIN {
     unless ( grep /blib/, @INC ) {

--- a/t/05-customxml.t
+++ b/t/05-customxml.t
@@ -1,4 +1,4 @@
-#!/bin/env perl
+#!/usr/bin/env perl
 
 BEGIN {
   unless(grep /blib/, @INC) {

--- a/t/06-modules.t
+++ b/t/06-modules.t
@@ -1,4 +1,4 @@
-#!/bin/env perl
+#!/usr/bin/env perl
 
 BEGIN {
 unless(grep /blib/, @INC) {

--- a/t/08-schema.t
+++ b/t/08-schema.t
@@ -1,4 +1,4 @@
-#!/bin/env perl
+#!/usr/bin/env perl
 
 BEGIN {
   unless(grep /blib/, @INC) {

--- a/t/11-cgi.t
+++ b/t/11-cgi.t
@@ -1,4 +1,4 @@
-#!/bin/env perl
+#!/usr/bin/env perl
 
 BEGIN {
   unless(grep /blib/, @INC) {

--- a/t/12-cgi_https.t
+++ b/t/12-cgi_https.t
@@ -1,4 +1,4 @@
-#!/bin/env perl
+#!/usr/bin/env perl
 
 BEGIN {
   unless(grep /blib/, @INC) {

--- a/t/13-mod_perl.t
+++ b/t/13-mod_perl.t
@@ -1,4 +1,4 @@
-#!/bin/env perl
+#!/usr/bin/env perl
 
 BEGIN {
   unless(grep /blib/, @INC) {

--- a/t/14-cgi_apache.t
+++ b/t/14-cgi_apache.t
@@ -1,4 +1,4 @@
-#!/bin/env perl
+#!/usr/bin/env perl
 
 BEGIN {
   unless(grep /blib/, @INC) {

--- a/t/15-daemon.t
+++ b/t/15-daemon.t
@@ -1,4 +1,4 @@
-#!/bin/env perl
+#!/usr/bin/env perl
 
 BEGIN {
   unless(grep /blib/, @INC) {

--- a/t/17-mod_soap.t
+++ b/t/17-mod_soap.t
@@ -1,4 +1,4 @@
-#!/bin/env perl
+#!/usr/bin/env perl
 
 BEGIN {
   unless(grep /blib/, @INC) {

--- a/t/19-apachesoap.t
+++ b/t/19-apachesoap.t
@@ -1,4 +1,4 @@
-#!/bin/env perl
+#!/usr/bin/env perl
 
 BEGIN {
   unless(grep /blib/, @INC) {

--- a/t/21-public.t
+++ b/t/21-public.t
@@ -1,4 +1,4 @@
-#!/bin/env perl
+#!/usr/bin/env perl
 
 BEGIN {
     unless(grep /blib/, @INC) {

--- a/t/22-interop_apache.t
+++ b/t/22-interop_apache.t
@@ -1,4 +1,4 @@
-#!/bin/env perl
+#!/usr/bin/env perl
 
 BEGIN {
   unless(grep /blib/, @INC) {

--- a/t/23-ppm.t
+++ b/t/23-ppm.t
@@ -1,4 +1,4 @@
-#!/bin/env perl
+#!/usr/bin/env perl
 
 BEGIN {
   unless(grep /blib/, @INC) {

--- a/t/24-wsdl.t
+++ b/t/24-wsdl.t
@@ -1,4 +1,4 @@
-#!/bin/env perl
+#!/usr/bin/env perl
 
 BEGIN {
   unless(grep /blib/, @INC) {


### PR DESCRIPTION
Fixes RT-118654

PAUSEID: MOTOTIMO
Signed-off-by: Tim Orling <timothy.t.orling@linux.intel.com>