### PR TITLE
Correct the soap namespace declaration when calling services defined in WSDL

### DIFF
--- a/lib/SOAP/Lite.pm
+++ b/lib/SOAP/Lite.pm
@@ -3412,6 +3412,7 @@ EOP
     my $namespaces = $self->deserializer->ids->[1];
     foreach my $key (keys %{$namespaces}) {
         my ($ns,$prefix) = SOAP::Utils::splitqname($key);
+        next if $namespaces->{$key} eq 'http://schemas.xmlsoap.org/wsdl/soap/';  #WAO 
         $self->{'_stub'} .= '  $self->serializer->register_ns("'.$namespaces->{$key}.'","'.$prefix.'");'."\n"
             if (defined $ns && ($ns eq "xmlns"));
     }

--- a/lib/SOAP/Lite.pm
+++ b/lib/SOAP/Lite.pm
@@ -3412,7 +3412,7 @@ EOP
     my $namespaces = $self->deserializer->ids->[1];
     foreach my $key (keys %{$namespaces}) {
         my ($ns,$prefix) = SOAP::Utils::splitqname($key);
-        next if $namespaces->{$key} eq 'http://schemas.xmlsoap.org/wsdl/soap/';  #WAO 
+        next if $namespaces->{$key} eq 'http://schemas.xmlsoap.org/wsdl/soap/';
         $self->{'_stub'} .= '  $self->serializer->register_ns("'.$namespaces->{$key}.'","'.$prefix.'");'."\n"
             if (defined $ns && ($ns eq "xmlns"));
     }


### PR DESCRIPTION
An unstable behavior was found when calling an external PHP SOAP web service.  Sometimes it worked, but sometimes it did not, returning the fabulous "Wrong version" error. The instability of the error has given a clue:  it comes from instability of Perl hash keys order.

The namespace declaration xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" can appear in the soap:Envelope instead of xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"  in the SOAP query.

The first of the declarations comes from parsing WSDL; the second is defined in Constants.pm (URI_SOAP11_ENV).
Both of the definitions conflict when creating the stub code, the result is random due to random order of keys in perl hash: sometimes soap is defined as wsdl/soap (incorrect), sometimes as soap/envelope.


The proposed solution looks like a hack, but I could't find a better way to filter out the soap namespace declaration extracted from the WSDL file.