### PR TITLE
Bad usage of UNIVERSAL::isa (See RT#62667)

### DIFF
--- a/lib/SOAP/Lite.pm
+++ b/lib/SOAP/Lite.pm
@@ -3524,7 +3524,7 @@ use SOAP::Lite::Utils;
 use SOAP::Constants;
 use SOAP::Packager;
 
-use Scalar::Util qw(weaken blessed);
+use Scalar::Util qw(weaken blessed reftype);
 
 @ISA = qw(SOAP::Cloneable);
 
@@ -3853,7 +3853,6 @@ sub call {
                 my($value) = $_->value; # take first value
 
                 # fillup parameters
-                use Scalar::Util 'reftype';
                 if ( reftype( $_[$param] ) ) {
                     if ( reftype( $_[$param] ) eq 'SCALAR' ) {
                         ${ $_[$param] } = $$value;


### PR DESCRIPTION
Hello,
The previous patch was rejected. Here is the patch used by Debian to close this bug (see https://bugs.debian.org/602056 for more).

The usage of UNIVERSAL::isa may be broken (extract from manpage):
    # but never do this!
    $is_io    = UNIVERSAL::isa($fd, "IO::Handle");
    $sub      = UNIVERSAL::can($obj, "print");

Regards,
Xavier