### PR TITLE
Empty input body support for operations in WSDL

### DIFF
--- a/lib/SOAP/Lite.pm
+++ b/lib/SOAP/Lite.pm
@@ -3334,6 +3334,13 @@ sub access {
     $req->proxy_authorization_basic($ENV{'HTTP_proxy_user'}, $ENV{'HTTP_proxy_pass'})
         if ($ENV{'HTTP_proxy_user'} && $ENV{'HTTP_proxy_pass'});
 
+    if(UNIVERSAL::can('SOAP::Transport::HTTP::Client', 'get_basic_credentials')) {
+        my ($http_user, $http_pass) = SOAP::Transport::HTTP::Client::get_basic_credentials();
+        if ($http_user && $http_pass) { 
+            $req->authorization_basic( $http_user, $http_pass); 
+        }
+    }
+
     my $resp = $self->useragent->request($req);
     $resp->is_success ? $resp->content : die "Service description '$url' can't be loaded: ",  $resp->status_line, "\n";
 }

--- a/lib/SOAP/Lite.pm
+++ b/lib/SOAP/Lite.pm
@@ -3176,8 +3176,9 @@ FAKE
                     $services{$opername} = {}; # should be initialized in 5.7 and after
                     my $soapaction = $_->operation->soapAction;
                     my $invocationStyle = $_->operation->style || $default_style || "rpc";
-                    my $encodingStyle = $_->input->body->use || "encoded";
-                    my $namespace = $_->input->body->namespace || $tns;
+                    my $inpBody = $_->input->body;
+                    my $encodingStyle = $inpBody ? $inpBody->use || "encoded" : "encoded";
+                    my $namespace = $inpBody ? $inpBody->namespace || $tns : $tns;
                     my @parts;
                     foreach ($s->portType) {
                         next unless $_->name eq $porttype;

--- a/t/25-wsdl.t
+++ b/t/25-wsdl.t
@@ -1,0 +1,33 @@
+#!/usr/bin/env perl
+
+BEGIN {
+  unless(grep /blib/, @INC) {
+    chdir 't' if -d 't';
+    unshift @INC, '../lib' if -d '../lib';
+  }
+}
+
+use strict;
+use Test;
+
+use SOAP::Lite
+  on_fault => sub {
+    my $soap = shift;
+    my $res = shift;
+    ref $res ? warn(join "\n", "--- SOAP FAULT ---", $res->faultcode, $res->faultstring, '')
+             : warn(join "\n", "--- TRANSPORT ERROR ---", $soap->transport->status, '');
+    return new SOAP::SOM;
+  }
+;
+
+my($s);
+
+plan tests => 1;
+
+{
+
+  ok($s = SOAP::Lite
+    ->service("https://demoapi.intickets.ru/soap/?wsdl&ver=1.6")
+  );
+
+}


### PR DESCRIPTION
Input section of an operation can have no <soap:body> elements, in this case WSDL parsing crushed.
The patch fixes this, the example is shown in the added test.